### PR TITLE
Fix .env issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,9 @@ import express from "express";
 import cors from "cors";
 import { icebreakerRoutes } from "./routes/icebreakerRoutes.js";
 import { pool } from "./database_connection.js";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 export const app = express();
 

--- a/database_connection.js
+++ b/database_connection.js
@@ -1,10 +1,12 @@
 // Import the pg (node-postgres) library
 import pg from "pg";
+import dotenv from "dotenv";
+
+// ensure .env config is pulled in
+dotenv.config();
 
 // Retrieve the database connection string from environment variables
-//const connectionString = process.env.DB_CONNECTION_STRING;
-const connectionString =
-  "postgres://tryfeacd:Gdnu52n15U5d-zkIo7bl_IVCTqAYNe51@tyke.db.elephantsql.com/tryfeacd";
+const connectionString = process.env.DB_CONNECTION_STRING;
 
 // Check if the connection string is not defined, and if so, throw an error
 if (!connectionString) {


### PR DESCRIPTION
This removes the hardcoded connection string and uses `process.env`